### PR TITLE
Fix unresolved symbol ext2fs_open_file

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -139,6 +139,7 @@
 						'deps/e2fsprogs/lib/ext2fs/symlink.c',
 						'deps/e2fsprogs/lib/ext2fs/tdb.c',
 						'deps/e2fsprogs/lib/ext2fs/unlink.c',
+						'deps/e2fsprogs/lib/ext2fs/unix_io.c',
 						'deps/e2fsprogs/lib/ext2fs/valid_blk.c',
 						'deps/e2fsprogs/lib/ext2fs/version.c',
 						'deps/e2fsprogs/lib/ext2fs/write_bb_file.c',


### PR DESCRIPTION
Somehow this error was only happening on linux ia32 builds.

Change-type: patch