### PR TITLE
Pin nan to 2.11.1 to avoid a build issue on node 10.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "async": "^2.6.1",
     "bluebird": "^3.5.3",
     "bindings": "^1.3.0",
-    "nan": "^2.11.1",
+    "nan": "2.11.1",
     "prebuild-install": "^5.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
```
In file included from ../src/node_ext2fs.cc:2:0:
../../nan/nan.h: In constructor 'Nan::Utf8String::Utf8String(v8::Local<v8::Value>)':
../../nan/nan.h:1081:101: error: no matching function for call to 'v8::String::WriteUtf8(v8::Isolate*, char*&, int, int, const int&)'
         length_ = string->WriteUtf8(v8::Isolate::GetCurrent(), str_, static_cast<int>(len), 0, flags);
                                                                                                     ^
In file included from /root/.node-gyp/10.4.0/include/node/node.h:63:0,
                 from ../../nan/nan.h:53,
                 from ../src/node_ext2fs.cc:2:
/root/.node-gyp/10.4.0/include/node/v8.h:2616:7: note: candidate: int v8::String::WriteUtf8(char*, int, int*, int) const
```

See https://github.com/nodejs/nan/issues/832